### PR TITLE
Binded to wrong turbolinks event

### DIFF
--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -25,4 +25,4 @@ $.fn.ready = (callback) ->
   callbacks.push(callback)
 
 # Bind `ready` to Tubolinks page change event
-$(document).on('page:change', ready)
+$(document).on('page:load', ready)


### PR DESCRIPTION
Turbolinks page:change fires every time a page is changed. When using back and forward as well. The back and forward dom is cached, however, and event bindings are preserved on the document.body nodes
