### PR TITLE
Load jQuery from global namespace first

### DIFF
--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -8,7 +8,7 @@
   Copyright (c) 2012 Sasha Koss
 ###
 
-$ = require?('jquery') || window.jQuery
+$ = window.jQuery or require?('jquery')
 
 # List for store callbacks passed to `$` or `$.ready`
 callbacks = []


### PR DESCRIPTION
This fixes the cases wherein you may be using an AMD system, but load jQuery outside AMD.

I ran into this issue when using jQuery.Turbolinks in a project wherein we use almond.js to manage AMD-compatible scripts, but 3rd-party libraries (jQuery, Backbone, Underscore, et al) are all loaded outside AMD.
