### PR TITLE
Clarify the load order

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Do you like [Turbolinks](https://github.com/rails/turbolinks)? It's easy and fas
 
 But if you have a large codebase with lots of `$(el).bind(...)` Turbolinks will surprise you. Most part of your JavaScripts will stop working in usual way. It's because the nodes on which you bind events no longer exist.
 
-I wrote jquery.turbolinks to solve this problem in [my project](http://amplifr.com). It's easy to use: just require it *after* `jquery.js` and `turbolinks.js`, but before other scripts.
+I wrote jquery.turbolinks to solve this problem in [my project](http://amplifr.com). It's easy to use: just require it *immediately after* `jquery.js`. Your other scripts should be loaded after `jquery.turbolinks.js`, and `turbolinks.js` should be after your other scripts.
 
 Sponsored by [Evil Martians](http://evilmartians.com/).
 


### PR DESCRIPTION
The load order should be jQuery -> jQuery.turbolinks -> other scripts -> Turbolinks.

This ensures that the jquery.turbolinks hijacks $.fn.ready so that other scripts can consume it.

Turbolinks then needs to be at the end of all scripts that can attach click handlers to links so that it will not intercept link clicks that should've been handled by other scripts.
