### PR TITLE
Revert unbinding of all event delegates

### DIFF
--- a/spec/jquery.turbolinks_spec.coffee
+++ b/spec/jquery.turbolinks_spec.coffee
@@ -46,24 +46,6 @@ describe '$ Turbolinks', ->
 
       callback1.should.have.been.calledWith($)
 
-    it '''
-         should remove all events delegated to
-         document after trigger fetch 
-       ''', ->
-         id       = getUniqId()
-         selector = '#' + id
-         addEl    = ->
-                      $('body').empty()
-                      $('<div>').attr(id: id).appendTo('body')
-
-         addEl()
-         $(document).on('event_name', selector, callback1)
-         $(selector).trigger('event_name')
-         $(document).trigger('page:fetch')
-         addEl()
-         $(selector).trigger('event_name')
-         callback1.should.have.been.calledOnce
-
     describe '$.setReadyEvent', ->
 
       beforeEach ->

--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -24,7 +24,6 @@ turbolinksReady = ->
 
 # Fetch event handler
 fetch = ->
-  $(document).off(undefined, '**')
   $.isReady = false
 
 # Bind `ready` to DOM ready event


### PR DESCRIPTION
This reverts the change introduced in #8. This fixes #14 and #12.

The code `$(document).off(undefined, '**')` breaks 3rd-party script behavior where events are delegated outside a `document.ready` wrapper, like Rails's jquery_ujs.

For instance, having code that looks like this will fail after navigating to a second page:

```
// [A]
$(document).on('click', 'button', function() { ... })
```

...this is exactly how scripts like jquery_ujs binds its events, and is prescribed in jQuery's documentation for [fn.live](http://api.jquery.com/live/).

To get around it, some people may wrap it in a `document.ready` wrapper like so. This is inefficient: events will then be bound and un-bound repeatedly as you navigate through pages.

```
// [B]
$(function() {
  $(document).on('click', 'button', function() { ... })
});
```

Therefore, [A] should be the recommended solution. This fix makes [A] work again, but breaks the behavior of [B].
