### PR TITLE
Adding run once callback

### DIFF
--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -11,13 +11,15 @@
 $ = window.jQuery or require?('jquery')
 
 # List for store callbacks passed to `$` or `$.ready`
-named_callbacks = {}
+non_idempotent_callback = null
 callbacks = []
 
 # Call each callback in list
 ready = ->
   callback($) for callback in callbacks
-  named_callbacks[key]($) for key in Object.keys(named_callbacks)
+  if non_idempotent_callback?
+    non_idempotent_callback($)
+    non_idempotent_callback = null
 
 # Turbolinks ready event
 turbolinksReady = ->
@@ -33,8 +35,8 @@ $(ready)
 
 # Store callbacks in list on `$` and `$.ready`
 $.fn.ready = (callback) ->
-  if name? and name != ""
-    named_callbacks[callback.name] = callback
+  if callback.name? and callback.name == "run_once"
+    non_idempotent_callback = callback
   else
     callbacks.push(callback)
   callback($) if $.isReady

--- a/vendor/assets/javascripts/jquery.turbolinks.js
+++ b/vendor/assets/javascripts/jquery.turbolinks.js
@@ -12,27 +12,24 @@
 
 
 (function() {
-  var $, callbacks, fetch, named_callbacks, ready, turbolinksReady;
+  var $, callbacks, fetch, non_idempotent_callback, ready, turbolinksReady;
 
   $ = window.jQuery || (typeof require === "function" ? require('jquery') : void 0);
 
-  named_callbacks = {};
+  non_idempotent_callback = null;
 
   callbacks = [];
 
   ready = function() {
-    var callback, key, _i, _j, _len, _len1, _ref, _results;
+    var callback, _i, _len;
     for (_i = 0, _len = callbacks.length; _i < _len; _i++) {
       callback = callbacks[_i];
       callback($);
     }
-    _ref = Object.keys(named_callbacks);
-    _results = [];
-    for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
-      key = _ref[_j];
-      _results.push(named_callbacks[key]($));
+    if (non_idempotent_callback != null) {
+      non_idempotent_callback($);
+      return non_idempotent_callback = null;
     }
-    return _results;
   };
 
   turbolinksReady = function() {
@@ -47,8 +44,8 @@
   $(ready);
 
   $.fn.ready = function(callback) {
-    if ((typeof name !== "undefined" && name !== null) && name !== "") {
-      named_callbacks[callback.name] = callback;
+    if ((callback.name != null) && callback.name === "run_once") {
+      non_idempotent_callback = callback;
     } else {
       callbacks.push(callback);
     }


### PR DESCRIPTION
I came across this problem when trying to trigger callbacks on the context of a single page, i. e., in one page I wanted to run some JS that should not be ran on another page.

Since the stuff on the `<head>` will only be evaled once, I added this code to the body, which means it will be ran every time and for non-idempotent functions this is a problem.

I solved by having a special function called `run_once`, that is not added to the callbacks, and runs only on the context of the page.

If this makes any sense I'll be glad to add tests to it. If there's a better way of doing it, even better.
