### PR TITLE
Patch behavior for added callbacks when DOM is already ready

### DIFF
--- a/spec/jquery.turbolinks_spec.coffee
+++ b/spec/jquery.turbolinks_spec.coffee
@@ -80,7 +80,7 @@ describe '$ Turbolinks', ->
         $.turbo.use('page:load', 'random_event_name')
         $(document).trigger('page:fetch')
         $.turbo.isReady.should.to.be.true
-        
+
       it 'should bind passed fetch event', ->
         $.turbo.use('page:load', 'page:loading')
         $(document).trigger('page:loading')
@@ -104,6 +104,15 @@ describe '$ Turbolinks', ->
       $(document).trigger('page:load')
       $(callback2 = sinon.spy())
       callback2.should.have.been.calledOnce
+
+    it 'should call trigger after a subsequent page:fetch and before page:load', ->
+      $(document).trigger('page:fetch')
+      $(document).trigger('page:load')
+      $(callback1 = sinon.spy())
+      callback1.should.have.been.calledOnce
+      $(document).trigger('page:fetch')
+      $(document).trigger('page:load')
+      callback1.should.have.been.calledTwice
 
     it 'should pass $ as the first argument to callbacks', (done) ->
       $ ($$) ->

--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -24,8 +24,7 @@ $.turbo =
   addCallback: (callback) ->
     if $.turbo.isReady
       callback($)
-    else
-      $document.on 'turbo:ready', -> callback($)
+    $document.on 'turbo:ready', -> callback($)
 
   onLoad: ->
     $.turbo.isReady = true


### PR DESCRIPTION
See #34

When loading scripts asynchronously, we noticed inconsistent behavior where the initial page load fired all of our handlers, but subsequent Turbolinks page loads did not fire any handlers.

This fix calls the callback immediately if the DOM is ready and binds to the page load event for subsequent Turbolinks page loads.
