### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,7 @@
 
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha ./spec/*_spec.coffee --compilers coffee:coffee-script/register -R spec -c"
-  }
+  },
+
+  "main": "./vendor/assets/javascripts/jquery.turbolinks.js"
 }


### PR DESCRIPTION
Hi :)

I'm experimenting with Webpack and wanted to use jquery.turbolinks with Node.

Basically I've just added an entry point to package.json so I can require the module.

Cheers,
Soeren