### PR TITLE
Use turbolinks 5 events

### DIFF
--- a/src/jquery.turbolinks.coffee
+++ b/src/jquery.turbolinks.coffee
@@ -46,4 +46,4 @@ $.turbo =
 
 # Use with Turbolinks.
 $.turbo.register()
-$.turbo.use('page:load', 'page:fetch')
+$.turbo.use('turbolinks:load', 'turbolinks:request-start')

--- a/vendor/assets/javascripts/jquery.turbolinks.js
+++ b/vendor/assets/javascripts/jquery.turbolinks.js
@@ -44,6 +44,6 @@ Copyright (c) 2012-2013 Sasha Koss & Rico Sta. Cruz
 
   $.turbo.register();
 
-  $.turbo.use('page:load', 'page:fetch');
+  $.turbo.use('turbolinks:load', 'turbolinks:request-start');
 
 }).call(this);


### PR DESCRIPTION
Changed:
* `page:load` to `turbolinks:load`
* `page:fetch` to `turbolinks:request-start`

Fixes #56 

I'll update the tests if this gem is not getting deprecated.