### PR TITLE
Prevent it from working on TL5

### DIFF
--- a/jquery-turbolinks.gemspec
+++ b/jquery-turbolinks.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.rubygems_version  = '1.8.15'
 
   gem.add_dependency 'railties', '>= 3.1.0'
-  gem.add_dependency 'turbolinks'
+  gem.add_dependency 'turbolinks', '< 4'
 end


### PR DESCRIPTION
As noted in many issues (#61 #62), Turbolinks 5 isn't supported.