### PR TITLE
Readme: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# :warning: Deprecated :warning:
+
+This gem does not work with Turbolinks 5+, and is not compatible with many jQuery plugins. We do not recommend using it. Instead, please consider writing your JavaScript in a way that makes it compatible with Turbolinks. These resources can help:
+
+- [RSJS](https://ricostacruz.com/rsjs) - A reasonable structure for JS, a document outlining how to write JavaScript as "behaviors" that will be compatible with Turbolinks.
+
+- [onmount](https://www.npmjs.com/package/onmount) - 1kb library to run something when a DOM element appears and when it exits.
+
+----
+
 # jQuery Turbolinks
 
 [![Build Status](https://secure.travis-ci.org/kossnocorp/jquery.turbolinks.png?branch=master)](http://travis-ci.org/kossnocorp/jquery.turbolinks)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # :warning: Deprecated :warning:
 
-This gem does not work with Turbolinks 5+, and is not compatible with many jQuery plugins. We do not recommend using it. Instead, please consider writing your JavaScript in a way that makes it compatible with Turbolinks. These resources can help:
+**This gem does not work with Turbolinks 5+, and is not compatible with many jQuery plugins. We do not recommend using it.** Instead, please consider writing your JavaScript in a way that makes it compatible with Turbolinks. These resources can help:
 
 - [RSJS](https://ricostacruz.com/rsjs) - A reasonable structure for JS, a document outlining how to write JavaScript as "behaviors" that will be compatible with Turbolinks.
 
 - [onmount](https://www.npmjs.com/package/onmount) - 1kb library to run something when a DOM element appears and when it exits.
+
+Rationale: making jQuery plugins compatible with Turbolinks requires more than simply dropping in a library. It should be able to setup and teardown its changes as needed, which is something you can't automate. jQuery Turbolinks's approach worked well enough for many libraries back in 2013, but today this is no longer the case. Given its utility is very limited, we've decided to no longer maintain this library.
 
 ----
 


### PR DESCRIPTION
As we talked about in many issues (recently [this](https://github.com/kossnocorp/jquery.turbolinks/issues/66#issuecomment-326790837)), jQuery.Turbolinks will no longer be updated.

I've added links to "alternatives" (if you can call it that):

- http://ricostacruz.com/rsjs/ - A document with instructions on how to write Turbolinks-compatible JS, and
- https://www.npmjs.com/package/onmount - a 1kb helper library to help with writing Turbolinks-compatible JS behaviors.